### PR TITLE
[ASSIGNMENT] 2차 과제 구현

### DIFF
--- a/src/main/java/org/sopt/controller/PostController.java
+++ b/src/main/java/org/sopt/controller/PostController.java
@@ -2,6 +2,7 @@ package org.sopt.controller;
 
 import org.sopt.dto.request.CreatePostRequest;
 import org.sopt.dto.request.UpdatePostRequest;
+import org.sopt.dto.response.ApiResponse;
 import org.sopt.dto.response.CreatePostResponse;
 import org.sopt.dto.response.PostResponse;
 import org.sopt.service.PostService;
@@ -21,47 +22,48 @@ public class PostController {
         this.postService = postService;
     }
 
-    // POST /posts ✅ 같이 구현
+    // POST /posts
     @PostMapping
-    public ResponseEntity<CreatePostResponse> createPost(
+    public ResponseEntity<ApiResponse<CreatePostResponse>> createPost(
             @RequestBody CreatePostRequest request
     ) {
         CreatePostResponse response = postService.createPost(request);
-        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success("게시글이 생성되었습니다.", response));
     }
 
-    // GET /posts 📝 과제
+    // GET /posts
     @GetMapping
-    public ResponseEntity<List<PostResponse>> getAllPosts() {
-        // TODO
-        return null;
+    public ResponseEntity<ApiResponse<List<PostResponse>>> getAllPosts() {
+        List<PostResponse> response = postService.getAllPosts();
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-    // GET /posts/{id} 📝 과제
+    // GET /posts/{id}
     @GetMapping("/{id}")
-    public ResponseEntity<PostResponse> getPost(
+    public ResponseEntity<ApiResponse<PostResponse>> getPost(
             @PathVariable Long id
     ) {
-        // TODO
-        return null;
+        PostResponse response = postService.getPost(id);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-    // PUT /posts/{id} 📝 과제
+    // PUT /posts/{id}
     @PutMapping("/{id}")
-    public ResponseEntity<Void> updatePost(
+    public ResponseEntity<ApiResponse<Void>> updatePost(
             @PathVariable Long id,
             @RequestBody UpdatePostRequest request
     ) {
-        // TODO
-        return null;
+        postService.updatePost(id, request);
+        return ResponseEntity.ok(ApiResponse.success(null));
     }
 
-    // DELETE /posts/{id} 📝 과제
+    // DELETE /posts/{id}
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deletePost(
+    public ResponseEntity<ApiResponse<Void>> deletePost(
             @PathVariable Long id
     ) {
-        // TODO
-        return null;
+        postService.deletePost(id);
+        return ResponseEntity.ok(ApiResponse.success("게시글이 삭제되었습니다.", null));
     }
 }

--- a/src/main/java/org/sopt/controller/PostController.java
+++ b/src/main/java/org/sopt/controller/PostController.java
@@ -34,8 +34,11 @@ public class PostController {
 
     // GET /posts
     @GetMapping
-    public ResponseEntity<ApiResponse<List<PostResponse>>> getAllPosts() {
-        List<PostResponse> response = postService.getAllPosts();
+    public ResponseEntity<ApiResponse<List<PostResponse>>> getAllPosts(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        List<PostResponse> response = postService.getAllPosts(page, size);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 

--- a/src/main/java/org/sopt/exception/BaseException.java
+++ b/src/main/java/org/sopt/exception/BaseException.java
@@ -1,0 +1,14 @@
+package org.sopt.exception;
+
+public class BaseException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public BaseException(ErrorCode errorCode) {
+        super(errorCode.toMessage());
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/org/sopt/exception/ErrorCode.java
+++ b/src/main/java/org/sopt/exception/ErrorCode.java
@@ -1,0 +1,26 @@
+package org.sopt.exception;
+
+import org.springframework.http.HttpStatus;
+
+public enum ErrorCode {
+    POST_NOT_FOUND("POST_001", "게시글을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    POST_INVALID_TITLE("POST_002", "제목은 비어있을 수 없습니다.", HttpStatus.BAD_REQUEST),
+    POST_TITLE_TOO_LONG("POST_003", "제목은 50자를 초과할 수 없습니다.", HttpStatus.BAD_REQUEST),
+    INVALID_INPUT("COMMON_001", "잘못된 입력값입니다.", HttpStatus.BAD_REQUEST),
+    INTERNAL_SERVER_ERROR("COMMON_002", "서버 내부 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+
+    private final String code;
+    private final String message;
+    private final HttpStatus httpStatus;
+
+    ErrorCode(String code, String message, HttpStatus httpStatus) {
+        this.code = code;
+        this.message = message;
+        this.httpStatus = httpStatus;
+    }
+
+    public String getCode() { return code; }
+    public String getMessage() { return message; }
+    public HttpStatus getHttpStatus() { return httpStatus; }
+    public String toMessage() { return "[" + code + "] " + message; }
+}

--- a/src/main/java/org/sopt/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/sopt/exception/GlobalExceptionHandler.java
@@ -11,19 +11,22 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(PostNotFoundException.class)
     public ResponseEntity<ApiResponse<Void>> handlePostNotFound(PostNotFoundException e) {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
                 .body(ApiResponse.error(e.getMessage()));
     }
 
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ApiResponse<Void>> handleIllegalArgument(IllegalArgumentException e) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
                 .body(ApiResponse.error(e.getMessage()));
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(ApiResponse.error("서버 내부 오류가 발생했습니다."));
     }
 }

--- a/src/main/java/org/sopt/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/sopt/exception/GlobalExceptionHandler.java
@@ -1,7 +1,6 @@
 package org.sopt.exception;
 
 import org.sopt.dto.response.ApiResponse;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -11,22 +10,24 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(PostNotFoundException.class)
     public ResponseEntity<ApiResponse<Void>> handlePostNotFound(PostNotFoundException e) {
+        ErrorCode errorCode = e.getErrorCode();
+
         return ResponseEntity
-                .status(HttpStatus.NOT_FOUND)
-                .body(ApiResponse.error(e.getMessage()));
+                .status(errorCode.getHttpStatus())
+                .body(ApiResponse.error(errorCode.toMessage()));
     }
 
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ApiResponse<Void>> handleIllegalArgument(IllegalArgumentException e) {
         return ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
-                .body(ApiResponse.error(e.getMessage()));
+                .status(ErrorCode.INVALID_INPUT.getHttpStatus())
+                .body(ApiResponse.error(ErrorCode.INVALID_INPUT.toMessage()));
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
         return ResponseEntity
-                .status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(ApiResponse.error("서버 내부 오류가 발생했습니다."));
+                .status(ErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus())
+                .body(ApiResponse.error(ErrorCode.INTERNAL_SERVER_ERROR.toMessage()));
     }
 }

--- a/src/main/java/org/sopt/exception/PostNotFoundException.java
+++ b/src/main/java/org/sopt/exception/PostNotFoundException.java
@@ -2,6 +2,6 @@ package org.sopt.exception;
 
 public class PostNotFoundException extends RuntimeException {
     public PostNotFoundException(Long id) {
-        super("해당 게시글이 존재하지 않습니다. id=" + id);
+        super(ErrorCode.POST_NOT_FOUND.toMessage());
     }
 }

--- a/src/main/java/org/sopt/exception/PostNotFoundException.java
+++ b/src/main/java/org/sopt/exception/PostNotFoundException.java
@@ -1,7 +1,11 @@
 package org.sopt.exception;
 
-public class PostNotFoundException extends RuntimeException {
+public class PostNotFoundException extends BaseException {
+    public PostNotFoundException() {
+        super(ErrorCode.POST_NOT_FOUND);
+    }
+
     public PostNotFoundException(Long id) {
-        super(ErrorCode.POST_NOT_FOUND.toMessage());
+        super(ErrorCode.POST_NOT_FOUND);
     }
 }

--- a/src/main/java/org/sopt/service/PostService.java
+++ b/src/main/java/org/sopt/service/PostService.java
@@ -41,9 +41,12 @@ public class PostService {
     }
 
     // READ ALL
-    public List<PostResponse> getAllPosts() {
-        return postRepository.findAll()
-                .stream()
+    public List<PostResponse> getAllPosts(int page, int size) {
+        List<Post> allPosts = postRepository.findAll();
+
+        return allPosts.stream()
+                .skip((long) page * size)
+                .limit(size)
                 .map(PostResponse::from)
                 .toList();
     }

--- a/src/main/java/org/sopt/service/PostService.java
+++ b/src/main/java/org/sopt/service/PostService.java
@@ -2,10 +2,15 @@ package org.sopt.service;
 
 import org.sopt.domain.Post;
 import org.sopt.dto.request.CreatePostRequest;
+import org.sopt.dto.request.UpdatePostRequest;
 import org.sopt.dto.response.CreatePostResponse;
+import org.sopt.dto.response.PostResponse;
+import org.sopt.exception.PostNotFoundException;
 import org.sopt.repository.PostRepository;
 import org.sopt.validator.PostValidator;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 public class PostService {
@@ -33,5 +38,37 @@ public class PostService {
 
         postRepository.save(post);
         return new CreatePostResponse(post.getId());
+    }
+
+    // READ ALL
+    public List<PostResponse> getAllPosts() {
+        return postRepository.findAll()
+                .stream()
+                .map(PostResponse::from)
+                .toList();
+    }
+
+    // READ ONE
+    public PostResponse getPost(Long id) {
+        Post post = postRepository.findById(id)
+                .orElseThrow(() -> new PostNotFoundException(id));
+        return PostResponse.from(post);
+    }
+
+    // UPDATE
+    public void updatePost(Long id, UpdatePostRequest request) {
+        postValidator.validateTitle(request.title());
+
+        Post post = postRepository.findById(id)
+                .orElseThrow(() -> new PostNotFoundException(id));
+        post.update(request.title(), request.content());
+    }
+
+    // DELETE
+    public void deletePost(Long id) {
+        boolean deleted = postRepository.deleteById(id);
+        if (!deleted) {
+            throw new PostNotFoundException(id);
+        }
     }
 }

--- a/src/main/java/org/sopt/validator/PostValidator.java
+++ b/src/main/java/org/sopt/validator/PostValidator.java
@@ -1,5 +1,7 @@
 package org.sopt.validator;
 
+import org.sopt.exception.BaseException;
+import org.sopt.exception.ErrorCode;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -9,10 +11,11 @@ public class PostValidator {
 
     public void validateTitle(String title) {
         if (title == null || title.isBlank()) {
-            throw new IllegalArgumentException("제목은 필수입니다!");
+            throw new BaseException(ErrorCode.POST_INVALID_TITLE);
         }
+
         if (title.length() > MAX_TITLE_LENGTH) {
-            throw new IllegalArgumentException("제목은 최대 " + MAX_TITLE_LENGTH + "자까지 가능합니다!");
+            throw new BaseException(ErrorCode.POST_TITLE_TOO_LONG);
         }
     }
 }


### PR DESCRIPTION
# 🔥 *Pull Requests*

- Closes #9

## 👷 **과제 구현**

### 필수과제
- [x] Read(전체) / Read(단건) / Update / Delete Controller, Service 구현
- [x] 게시글 목록 / 상세 / 작성 / 수정 / 삭제 API에 대한 API 명세서 작성
https://frost-eater-29e.notion.site/API-34aca0dd8597800e8bdac49b25d2c418
- [x] PostNotFoundException 커스텀 예외 클래스 및 @RestControllerAdvice 구현
- [x] ApiResponse<T> 공통 응답 객체 설계 및 적용
- [x] Postman 테스트 및 캡처 첨부

<br>

### 선택과제
- [x] Pagination 적용 (GET /posts?page=0&size=10)
- [ ] PostRepository 인터페이스 분리 및 InMemoryPostRepository 구현
- [x] ErrorCode enum 관리
- [ ] BoardType enum 추가 및 게시판 종류별 조회 API 구현

<br>

### **구현한 내용에 대해서 설명해주세요**

이번 과제에서는 세미나에서 다뤘던 Create 외의 기능인 전체 조회, 단건 조회, 수정, 삭제 기능을 구현했습니다.

또한 예외 상황을 조금 더 명확하게 처리하기 위해 `ErrorCode` enum을 도입해 에러 코드와 메시지를 한곳에서 관리하도록 하고, `@RestControllerAdvice`를 통해 예외가 발생했을 때 일관된 형식으로 응답할 수 있도록 구성했습니다.

게시글 목록 조회에는 pagination을 적용해 `page`, `size` 기준으로 데이터를 조회할 수 있도록 구현했습니다.

Postman으로 각 API를 테스트한 결과를 첨부하겠습니다!

<details>
<summary><h4>📸 API 테스트 결과</h4></summary>

- 게시글 등록
<img width="679" height="727" alt="image" src="https://github.com/user-attachments/assets/ce93164f-e621-4413-8ee8-eb83f4efe273" />

- 게시글 목록 조회
<img width="679" height="727" alt="image" src="https://github.com/user-attachments/assets/7fa049c8-698f-4559-a70f-232adae8f297" />

- 게시글 단건 조회
<img width="679" height="727" alt="image" src="https://github.com/user-attachments/assets/b4965342-448e-4387-97e5-bfeae26914a0" />

- 게시글 수정
<img width="679" height="727" alt="image" src="https://github.com/user-attachments/assets/b75c35c2-11e1-4ba1-8f96-f7b2158e6732" />

- 게시글 삭제
<img width="679" height="727" alt="image" src="https://github.com/user-attachments/assets/83b6ed70-2f51-44c8-82b0-691d678e0f9d" />

</details>

<br>


### **구현하며 고민했던 내용을 적어주세요 (사소한 것도 좋아요)**

이번 과제에서는 예외 처리를 일관되게 가져가고 싶어서 에러 코드를 어떻게 관리할지 고민했습니다.  
처음에는 예외마다 메시지를 직접 작성했는데, 심화 과제에 맞게 `ErrorCode` enum으로 코드, 메시지, 상태 코드를 함께 관리하고, 응답도 `[CODE] message` 형식으로 맞췄습니다.


<br>

---
### **키워드 과제 정리 내용**
<details>
<summary><h4>HTTP의 멱등성(Idempotency)이란 무엇인가요?</h4></summary>

멱등성이란 같은 요청을 여러 번 보내도 서버 상태가 한 번 보낸 것과 같게 유지되는 성질을 말한다.
예를 들어, 게시글 조회 API를 여러 번 호출한다고 해서 게시글 데이터가 계속 바뀌지는 않는다면, 이는 멱등하다고 볼 수 있다.
반대로 게시글 생성 API는 같은 요청을 여러 번 보내면 게시글이 여러 개 생길 수 있다. 이 경우는 멱등하지 않다.

각 메서드를 보면 다음과 같다.

| 메서드 | 멱등성 | 이유 |
| --- | --- | --- |
| `GET` | O | 여러 번 조회해도 서버의 데이터 상태는 바뀌지 않는다. |
| `POST` | X | 같은 요청을 반복하면 리소스가 중복 생성될 수 있다. |
| `PUT` | O | 같은 데이터를 여러 번 덮어써도 최종 상태는 동일하다. |
| `DELETE` | O | 여러 번 요청하더라도 결과적으로 리소스는 삭제된 상태로 유지된다. |

즉, `GET`, `PUT`, `DELETE`는 멱등하고, `POST`는 멱등하지 않다.

</details>
<details>
<summary><h4>@Controller와 @RestController의 차이는 무엇인가요?</h4></summary>

Controller와 RestController 둘다 Spring에서 Controller를 지정해주기 위한 어노테이션이지만,
Response Body가 생성되는 방식에서 차이가 있다.

- @Controller

전통적인 Spring MVC 방식에서 주로 View를 반환할 때 사용하는 어노테이션이다.
1. 클라이언트 요청
2. DispatcherServlet → HandlerMapping으로 매핑
3. 컨트롤러 실행, View Name 반환
4. DispatcherServlet이 ViewResolver를 통해 해당 뷰를 찾아 렌더링

다만 ResponseBody를 함께 붙이면, 반환한 객체를 View로 해석하지 않고 HTTP 응답 본문에 바로 담아 보낼 수 있다. 이 과정에서는 ViewResolver 대신 HttpMessageConverter가 동작하고, JSON 응답이라면 보통 자바 객체를 JSON으로 변환해서 내려주게 된다.

- @RestController

Controller와 ResponseBody의 결합체 같은 개념으로,
View를 찾지 않고 반환 객체를 HttpMessageConverter로 직렬화해 JSON 형태의 응답을 내려준다.


</details>
<details>
<summary><h4>Java Record란 무엇인가요? 기존 클래스와 비교해서 어떤 점이 다른가요?</h4></summary>

Java Record는 데이터를 담기 위한 객체를 더 간단하게 만들 수 있도록 나온 문법이다.
Record의 특징으로는,
- 데이터의 불변성 보장
- equals, hashCode, toString 메소드 자동 생성
- 접근자 이름이 getTitle()이 아니라 title()처럼 필드명 그대로 생성된다.

주로 DTO처럼 값을 전달하는 객체를 만들 때 많이 사용한다.

기존 클래스 방식에 따르면,
```
public class UpdatePostRequest {
    private final String title;
    private final String content;

    public UpdatePostRequest(String title, String content) {
        this.title = title;
        this.content = content;
    }

    public String getTitle() {
        return title;
    }

    public String getContent() {
        return content;
    }
}
```
이런 객체를 만들 때 필드, 생성자, getter, toString(), equals(), hashCode() 같은 코드를 직접 작성해야 했다.
하지만 Record를 사용하면 이런 반복적인 코드(보일러 플레이트 코드)를 훨씬 줄일 수 있다.

```
public record UpdatePostRequest(
        String title,
        String content
) {
}
```
이렇게만 써도 생성자, 접근자 메서드, equals(), hashCode(), toString()이 자동으로 만들어지기 때문에 코드를 반복할 필요가 없어진다!

</details>
<details>
<summary><h4>Optional이란 무엇이고, 왜 null 대신 쓰는 건가요?</h4></summary>

Optional은 어떤 메서드의 반환값이 비어 있을 가능성을 나타내는 객체이다.
이는 null과 비슷한 개념을 가지지만, 확연한 차이가 있다.
null은 사용할 때마다 직접 체크해줘야 하고, 이를 놓치면 NullPointerException이 발생할 수 있는 반면,
Optional을 사용하면 값이 없을 수 있다는 사실을 명시적으로 표현할 수 있고, 예외 처리 흐름을 더 분명하게 만들 수 있다.

```
public Optional<Post> findById(Long id) {
    return postList.stream()
            .filter(post -> post.getId().equals(id))
            .findFirst();
}
```
이런 식으로 Optional로 감싼 후

```
Post post = postRepository.findById(id)
        .orElseThrow(PostNotFoundException::new);
```
서비스 계층에서 예외처리 흐름을 덧붙이면 된다.

</details>
<details>
<summary><h4>Spring Bean의 생명주기란 무엇인가요?</h4></summary>

스프링 컨테이너가 Bean 객체를 생성하고, 의존성을 주입하고, 초기화한 뒤 사용하다가, 마지막에 소멸시키는 전체 과정이다.
여기서 Bean은 스프링이 관리하는 객체이고, @Controller, @Service, @Repositoryt 같은 어노테이션이 붙은 클래스를 말한다.

Bean의 생명주기를 흐름대로 보면 다음과 같다.

1. Bean 객체 생성
2. 의존성 주입
3. Bean이 사용되기 전에 필요한 설정 작업(초기화)을 진행
4. Bean 관리 & 필요한 곳에 제공
5. Bean 소멸

이처럼 Spring Bean의 생명주기는 객체의 생성, 관리, 소멸까지의 전 과정을 말한다.

</details>
<details>
<summary><h4>Spring Boot의 구동 원리를 DispatcherServlet 동작 방식 위주로 정리해주세요.</h4></summary>

Spring Boot 애플리케이션이 실행되면 내장 톰캣이 함께 올라가고, 스프링 컨테이너가 빈을 생성하고 관리한다.  
이후 클라이언트 요청이 들어오면 가장 먼저 `DispatcherServlet`이 이를 받는다.
`DispatcherServlet`은 스프링 MVC의 프론트 컨트롤러로, 모든 요청을 한곳에서 받아 적절한 흐름으로 분배하는 역할을 한다.

동작 흐름은 아래와 같다.

1. 클라이언트가 HTTP 요청을 보낸다.
2. 내장 톰캣이 요청을 받고, 이를 스프링의 `DispatcherServlet`에게 전달한다.
3. `DispatcherServlet`은 어떤 컨트롤러가 이 요청을 처리해야 하는지 `HandlerMapping`을 통해 찾는다.
4. 알맞은 컨트롤러 메서드를 찾으면 `HandlerAdapter`를 통해 해당 메서드를 실행한다.
5. 컨트롤러는 비즈니스 로직이 필요한 경우 Service를 호출하고, Service는 다시 Repository를 호출한다.
6. 처리가 끝나면 컨트롤러는 결과 데이터를 반환하고, `DispatcherServlet`은 이를 HTTP 응답 형태로 변환해 클라이언트에게 전달한다.

</details>

<br>


