### PR TITLE
[SEMINAR] 6차 세미나 실습 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+    implementation 'com.auth0:java-jwt:4.4.0'
     runtimeOnly 'com.mysql:mysql-connector-j'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/src/main/java/org/sopt/config/JwtAuthFilter.java
+++ b/src/main/java/org/sopt/config/JwtAuthFilter.java
@@ -1,0 +1,51 @@
+package org.sopt.config;
+
+import com.auth0.jwt.exceptions.JWTVerificationException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.sopt.service.JwtService;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Collections;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthFilter extends OncePerRequestFilter {
+
+    private final JwtService jwtService;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        String header = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (header != null && header.startsWith("Bearer ")) {
+            String token = header.substring("Bearer ".length()).trim();
+            try {
+                Long memberId = jwtService.verifyAndGetUserId(token);
+                UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
+                        String.valueOf(memberId), null, Collections.emptyList());
+                auth.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(auth);
+            } catch (IllegalArgumentException | JWTVerificationException e) {
+                // 유효하지 않은 토큰 또는 토큰이 없는 경우, 인증 없이 다음 필터로 넘겨요.
+                // 여기서 예외를 던지지 않는 이유는, /v1/login 같이 인증이 필요 없는 API도
+                // 이 필터를 거치기 때문이에요. 인증 여부 판단은 SecurityConfig의
+                // authorizeHttpRequests 설정에서 담당합니다.
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/org/sopt/config/SecurityConfig.java
+++ b/src/main/java/org/sopt/config/SecurityConfig.java
@@ -24,7 +24,7 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/v1/login", "/v1/reissue").permitAll()
+                        .requestMatchers("/api/v1/auth/login").permitAll()
                         .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/org/sopt/config/SecurityConfig.java
+++ b/src/main/java/org/sopt/config/SecurityConfig.java
@@ -1,0 +1,34 @@
+package org.sopt.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtAuthFilter jwtAuthFilter;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/v1/login", "/v1/reissue").permitAll()
+                        .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
+        return http.build();
+    }
+}

--- a/src/main/java/org/sopt/controller/AuthController.java
+++ b/src/main/java/org/sopt/controller/AuthController.java
@@ -1,10 +1,12 @@
 package org.sopt.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.sopt.domain.User;
+import org.sopt.dto.request.UserPostRequest;
 import org.sopt.dto.response.BaseResponse;
 import org.sopt.dto.response.TokenResponse;
+import org.sopt.dto.response.UserResponse;
 import org.sopt.service.AuthService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -20,25 +22,24 @@ public class AuthController {
     @Operation(summary = "로그인 (Access Token + Refresh Token 발급)")
     @PostMapping("/login")
     public ResponseEntity<BaseResponse<TokenResponse>> login(
-            @RequestParam("email") String email,
-            @RequestParam("password") String password
+            @RequestBody @Valid UserPostRequest request
     ) {
-        TokenResponse tokens = authService.login(email, password);
+        TokenResponse tokens = authService.login(request.email(), request.password());
 
         return ResponseEntity.ok(BaseResponse.success(tokens));
     }
 
     @Operation(summary = "내 정보 조회 (Access Token 검증)")
     @GetMapping("/me")
-    public ResponseEntity<BaseResponse<User>> me(Authentication authentication) {
+    public ResponseEntity<BaseResponse<UserResponse>> me(Authentication authentication) {
 
         if (authentication == null || authentication.getPrincipal() == null) {
             throw new IllegalArgumentException("인증되지 않았습니다.");
         }
 
         Long memberId = Long.parseLong(authentication.getName());
-        User member = authService.getUserById(memberId);
+        UserResponse userResponse = UserResponse.from(authService.getUserById(memberId));
 
-        return ResponseEntity.ok(BaseResponse.success(member));
+        return ResponseEntity.ok(BaseResponse.success(userResponse));
     }
 }

--- a/src/main/java/org/sopt/controller/AuthController.java
+++ b/src/main/java/org/sopt/controller/AuthController.java
@@ -1,0 +1,44 @@
+package org.sopt.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.sopt.domain.User;
+import org.sopt.dto.response.BaseResponse;
+import org.sopt.dto.response.TokenResponse;
+import org.sopt.service.AuthService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    @Operation(summary = "로그인 (Access Token + Refresh Token 발급)")
+    @PostMapping("/login")
+    public ResponseEntity<BaseResponse<TokenResponse>> login(
+            @RequestParam("email") String email,
+            @RequestParam("password") String password
+    ) {
+        TokenResponse tokens = authService.login(email, password);
+
+        return ResponseEntity.ok(BaseResponse.success(tokens));
+    }
+
+    @Operation(summary = "내 정보 조회 (Access Token 검증)")
+    @GetMapping("/me")
+    public ResponseEntity<BaseResponse<User>> me(Authentication authentication) {
+
+        if (authentication == null || authentication.getPrincipal() == null) {
+            throw new IllegalArgumentException("인증되지 않았습니다.");
+        }
+
+        Long memberId = Long.parseLong(authentication.getName());
+        User member = authService.getUserById(memberId);
+
+        return ResponseEntity.ok(BaseResponse.success(member));
+    }
+}

--- a/src/main/java/org/sopt/domain/RefreshToken.java
+++ b/src/main/java/org/sopt/domain/RefreshToken.java
@@ -1,0 +1,46 @@
+package org.sopt.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Column(nullable = false, unique = true)
+    private String token;
+
+    @Column(nullable = false)
+    private LocalDateTime expiresAt;
+
+    private RefreshToken(Long userId, String token, LocalDateTime expiresAt) {
+        this.userId = userId;
+        this.token = token;
+        this.expiresAt = expiresAt;
+    }
+
+    public static RefreshToken of(Long userId, String token, long expiresInSeconds) {
+        return new RefreshToken(
+                userId,
+                token,
+                LocalDateTime.now().plusSeconds(expiresInSeconds)
+        );
+    }
+
+    public void rotate(String newToken, long expiresInSeconds) {
+        this.token = newToken;
+        this.expiresAt = LocalDateTime.now().plusSeconds(expiresInSeconds);
+    }
+}

--- a/src/main/java/org/sopt/domain/User.java
+++ b/src/main/java/org/sopt/domain/User.java
@@ -15,6 +15,8 @@ public class User {
     private String email;
     private String password;
 
+    protected User() {}
+
     public User(String nickname, String email, String password) {
         this.nickname = nickname;
         this.email = email;

--- a/src/main/java/org/sopt/domain/User.java
+++ b/src/main/java/org/sopt/domain/User.java
@@ -11,13 +11,14 @@ public class User {
     private Long id;
 
     private String nickname;
+
     private String email;
+    private String password;
 
-    protected User() {}
-
-    public User(String nickname, String email) {
+    public User(String nickname, String email, String password) {
         this.nickname = nickname;
         this.email = email;
+        this.password = password;
     }
 
     public Long getId() {
@@ -30,5 +31,9 @@ public class User {
 
     public String getEmail() {
         return this.email;
+    }
+
+    public String getPassword() {
+        return this.password;
     }
 }

--- a/src/main/java/org/sopt/dto/request/UserPostRequest.java
+++ b/src/main/java/org/sopt/dto/request/UserPostRequest.java
@@ -1,0 +1,15 @@
+package org.sopt.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record UserPostRequest(
+        @Schema(description = "이메일")
+        @NotBlank(message = "이메일은 비어있을 수 없습니다.")
+        String email,
+
+        @Schema(description = "비밀번호")
+        @NotBlank(message = "비밀번호는 비어있을 수 없습니다.")
+        String password
+) {
+}

--- a/src/main/java/org/sopt/dto/response/TokenResponse.java
+++ b/src/main/java/org/sopt/dto/response/TokenResponse.java
@@ -1,0 +1,11 @@
+package org.sopt.dto.response;
+
+public record TokenResponse(
+        String accessToken,
+        String refreshToken
+) {
+
+    public static TokenResponse of(String accessToken, String refreshToken) {
+        return new TokenResponse(accessToken, refreshToken);
+    }
+}

--- a/src/main/java/org/sopt/dto/response/UserResponse.java
+++ b/src/main/java/org/sopt/dto/response/UserResponse.java
@@ -1,0 +1,19 @@
+package org.sopt.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.sopt.domain.User;
+
+public record UserResponse(
+        @Schema(description = "사용자 ID")
+        Long id,
+
+        @Schema(description = "닉네임")
+        String nickname,
+
+        @Schema(description = "이메일")
+        String email
+) {
+    public static UserResponse from(User user) {
+        return new UserResponse(user.getId(), user.getNickname(), user.getEmail());
+    }
+}

--- a/src/main/java/org/sopt/repository/RefreshTokenRepository.java
+++ b/src/main/java/org/sopt/repository/RefreshTokenRepository.java
@@ -1,0 +1,11 @@
+package org.sopt.repository;
+
+import org.sopt.domain.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByToken(String token);
+    void deleteByUserId(Long userId);
+}

--- a/src/main/java/org/sopt/repository/UserRepository.java
+++ b/src/main/java/org/sopt/repository/UserRepository.java
@@ -8,5 +8,5 @@ import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
-    Optional<Object> findByEmail(String email);
+    Optional<User> findByEmail(String email);
 }

--- a/src/main/java/org/sopt/repository/UserRepository.java
+++ b/src/main/java/org/sopt/repository/UserRepository.java
@@ -4,6 +4,9 @@ import org.sopt.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<Object> findByEmail(String email);
 }

--- a/src/main/java/org/sopt/service/AuthService.java
+++ b/src/main/java/org/sopt/service/AuthService.java
@@ -1,0 +1,55 @@
+package org.sopt.service;
+
+import lombok.RequiredArgsConstructor;
+
+import org.sopt.domain.RefreshToken;
+import org.sopt.domain.User;
+import org.sopt.dto.response.TokenResponse;
+import org.sopt.repository.RefreshTokenRepository;
+import org.sopt.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtService jwtService;
+
+    @Value("${security.jwt.refresh-token-expires-in-seconds:1209600}")
+    private long refreshTokenExpiresInSeconds;
+
+    private User findByCredentials(String email, String password) {
+        User user = (User) userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+
+        if (!user.getPassword().equals(password)) {
+            throw new IllegalArgumentException("이메일 또는 비밀번호가 올바르지 않습니다.");
+        }
+
+        return user;
+    }
+
+    @Transactional
+    public TokenResponse login(String email, String password) {
+        User user = findByCredentials(email, password);
+
+        String accessToken = jwtService.generateAccessToken(user.getId(), user.getEmail());
+        String refreshToken = jwtService.generateRefreshToken(user.getId());
+
+        refreshTokenRepository.deleteByUserId(user.getId());
+        refreshTokenRepository.save(
+                RefreshToken.of(user.getId(), refreshToken, refreshTokenExpiresInSeconds)
+        );
+
+        return TokenResponse.of(accessToken, refreshToken);
+    }
+
+    public User getUserById(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+    }
+}

--- a/src/main/java/org/sopt/service/AuthService.java
+++ b/src/main/java/org/sopt/service/AuthService.java
@@ -23,7 +23,7 @@ public class AuthService {
     private long refreshTokenExpiresInSeconds;
 
     private User findByCredentials(String email, String password) {
-        User user = (User) userRepository.findByEmail(email)
+        User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
 
         if (!user.getPassword().equals(password)) {

--- a/src/main/java/org/sopt/service/JwtService.java
+++ b/src/main/java/org/sopt/service/JwtService.java
@@ -1,0 +1,59 @@
+package org.sopt.service;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.Date;
+
+@Service
+public class JwtService {
+
+    private final Algorithm algorithm;
+    private final long accessTokenExpiresInSeconds;
+    private final long refreshTokenExpiresInSeconds;
+
+    public JwtService(
+            @Value("${security.jwt.secret}") String secret,
+            @Value("${security.jwt.access-token-expires-in-seconds:1800}") long accessTokenExpiresInSeconds,
+            @Value("${security.jwt.refresh-token-expires-in-seconds:1209600}") long refreshTokenExpiresInSeconds
+    ) {
+        this.algorithm = Algorithm.HMAC256(secret);
+        this.accessTokenExpiresInSeconds = accessTokenExpiresInSeconds;
+        this.refreshTokenExpiresInSeconds = refreshTokenExpiresInSeconds;
+    }
+
+    public String generateAccessToken(Long userId, String email) {
+        Instant now = Instant.now();
+        return JWT.create()
+                .withSubject(String.valueOf(userId))
+                .withClaim("email", email)
+                .withIssuedAt(Date.from(now))
+                .withExpiresAt(Date.from(now.plusSeconds(accessTokenExpiresInSeconds)))
+                .sign(algorithm);
+    }
+
+    public String generateRefreshToken(Long userId) {
+        Instant now = Instant.now();
+        return JWT.create()
+                .withSubject(String.valueOf(userId))
+                .withIssuedAt(Date.from(now))
+                .withExpiresAt(Date.from(now.plusSeconds(refreshTokenExpiresInSeconds)))
+                .sign(algorithm);
+    }
+
+    public Long verifyAndGetUserId(String token) {
+        if (token == null || token.isBlank()) {
+            throw new IllegalArgumentException("토큰이 없습니다.");
+        }
+        DecodedJWT jwt = JWT.require(algorithm).build().verify(token);
+        try {
+            return Long.parseLong(jwt.getSubject());
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("JWT의 회원 정보가 올바르지 않습니다.");
+        }
+    }
+}

--- a/src/main/java/org/sopt/service/PostService.java
+++ b/src/main/java/org/sopt/service/PostService.java
@@ -73,6 +73,7 @@ public class PostService {
         post.update(request.title(), request.content());
     }
     // DELETE
+    @Transactional
     public void deletePost(Long id) {
         Post post = postRepository.findById(id)
                 .orElseThrow(() -> new PostNotFoundException(id));

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,5 +17,11 @@ spring:
         format_sql: true
     show-sql: true
 
-  server:
-    forward-headers-strategy: framework
+server:
+  forward-headers-strategy: framework
+
+security:
+  jwt:
+    secret: ${JWT_SECRET}
+    access-token-expires-in-seconds: 1800     # 30분
+    refresh-token-expires-in-seconds: 1209600 # 2주


### PR DESCRIPTION
# 🔥 *Pull Requests*

- Closes #19

### **구현한 내용에 대해서 설명해주세요**

  - `JwtService`: Access Token(30분), Refresh Token(2주) 발급 및 검증
  - `JwtAuthFilter`: 요청마다 `Authorization: Bearer` 헤더를 파싱해 토큰 검증 후 `SecurityContext`에 인증 정보 설정
  - `SecurityConfig`: CSRF 비활성화, 세션 Stateless 설정, Swagger 및 로그인 경로 인증 제외
  - `AuthService`: 이메일/비밀번호 검증 후 토큰 발급, 로그인 시 기존 Refresh Token 삭제 후 재발급
  - `UserResponse` DTO 도입

<br>

