### PR TITLE
[ASSIGNMENT] 7차 과제 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,14 +18,31 @@ repositories {
 }
 
 dependencies {
+    // Spring Boot
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+
+    // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+
+    // JWT
     implementation 'com.auth0:java-jwt:4.4.0'
+
+    // Database
     runtimeOnly 'com.mysql:mysql-connector-j'
+
+    // Lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+
+    // QueryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+
+    // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/src/main/java/org/sopt/config/QueryDslConfig.java
+++ b/src/main/java/org/sopt/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package org.sopt.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/org/sopt/controller/AuthController.java
+++ b/src/main/java/org/sopt/controller/AuthController.java
@@ -82,8 +82,8 @@ public class AuthController {
     @Operation(summary = "내 정보 조회")
     @GetMapping("/me")
     public ResponseEntity<BaseResponse<UserResponse>> me(Authentication authentication) {
-        Long memberId = (Long) authentication.getPrincipal();
-        UserResponse userResponse = UserResponse.from(authService.getUserById(memberId));
+        Long userId = (Long) authentication.getPrincipal();
+        UserResponse userResponse = UserResponse.from(authService.getUserById(userId));
 
         return ResponseEntity.ok(BaseResponse.success(userResponse));
     }

--- a/src/main/java/org/sopt/controller/PostController.java
+++ b/src/main/java/org/sopt/controller/PostController.java
@@ -19,6 +19,7 @@ import org.sopt.dto.response.CreatePostResponse;
 import org.sopt.dto.response.PostResponse;
 import org.sopt.service.PostService;
 import org.springframework.data.domain.Page;
+import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -51,6 +52,25 @@ public class PostController {
         CreatePostResponse response = postService.createPost(userId, request);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(BaseResponse.success("게시글이 생성되었습니다.", response));
+    }
+
+    // GET /posts/search
+    @Operation(summary = "게시글 검색", description = "제목 키워드와 작성자 닉네임으로 게시글을 검색합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "게시글 검색 성공"),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류가 발생했습니다.",
+                    content = @Content(schema = @Schema(implementation = BaseResponse.class)))
+    })
+    @GetMapping("/search")
+    public ResponseEntity<BaseResponse<List<PostResponse>>> searchPosts(
+            @Parameter(description = "제목 키워드", example = "제목")
+            @RequestParam(required = false) String title,
+
+            @Parameter(description = "작성자 닉네임", example = "김소연")
+            @RequestParam(required = false) String nickname
+    ) {
+        List<PostResponse> response = postService.searchPosts(title, nickname);
+        return ResponseEntity.ok(BaseResponse.success(response));
     }
 
     // GET /posts

--- a/src/main/java/org/sopt/repository/LikeRepository.java
+++ b/src/main/java/org/sopt/repository/LikeRepository.java
@@ -4,10 +4,16 @@ import org.sopt.domain.Like;
 import org.sopt.domain.Post;
 import org.sopt.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface LikeRepository extends JpaRepository<Like, Long> {
     Optional<Like> findByUserAndPost(User user, Post post);
     Long countByPost(Post post);
+
+    @Query("SELECT l.post.id, COUNT(l) FROM Like l WHERE l.post.id IN :postIds GROUP BY l.post.id")
+    List<Object[]> countByPostIds(@Param("postIds") List<Long> postIds);
 }

--- a/src/main/java/org/sopt/repository/PostRepository.java
+++ b/src/main/java/org/sopt/repository/PostRepository.java
@@ -9,7 +9,7 @@ import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface PostRepository extends JpaRepository<Post, Long> {
+public interface PostRepository extends JpaRepository<Post, Long>, PostRepositoryCustom {
     @Query("SELECT p FROM Post p JOIN FETCH p.user")
     Page<Post> findAll(@NonNull Pageable pageable);
 }

--- a/src/main/java/org/sopt/repository/PostRepositoryCustom.java
+++ b/src/main/java/org/sopt/repository/PostRepositoryCustom.java
@@ -1,0 +1,10 @@
+package org.sopt.repository;
+
+import org.sopt.domain.Post;
+
+import java.util.List;
+
+public interface PostRepositoryCustom {
+
+    List<Post> searchPosts(String title, String nickname);
+}

--- a/src/main/java/org/sopt/repository/PostRepositoryCustomImpl.java
+++ b/src/main/java/org/sopt/repository/PostRepositoryCustomImpl.java
@@ -1,0 +1,42 @@
+package org.sopt.repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.sopt.domain.Post;
+
+import java.util.List;
+
+import static org.sopt.domain.QPost.post;
+
+@RequiredArgsConstructor
+public class PostRepositoryCustomImpl implements PostRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Post> searchPosts(String title, String nickname) {
+        return queryFactory
+                .selectFrom(post)
+                .join(post.user).fetchJoin()
+                .where(
+                        titleContains(title),
+                        nicknameContains(nickname)
+                )
+                .fetch();
+    }
+
+    private BooleanExpression titleContains(String title) {
+        if (title == null || title.isBlank()) {
+            return null;
+        }
+        return post.title.contains(title);
+    }
+
+    private BooleanExpression nicknameContains(String nickname) {
+        if (nickname == null || nickname.isBlank()) {
+            return null;
+        }
+        return post.user.nickname.contains(nickname);
+    }
+}

--- a/src/main/java/org/sopt/security/JwtAuthFilter.java
+++ b/src/main/java/org/sopt/security/JwtAuthFilter.java
@@ -36,13 +36,13 @@ public class JwtAuthFilter extends OncePerRequestFilter {
         if (header != null && header.startsWith("Bearer ")) {
             String token = header.substring("Bearer ".length()).trim();
             try {
-                Long memberId = jwtService.verifyAndGetUserId(token);
+                Long userId = jwtService.verifyAndGetUserId(token);
                 if (blacklistRepository.existsByToken(token)) {
                     securityErrorHandler.sendUnauthorized(response);
                     return;
                 }
                 UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
-                        memberId, null, Collections.emptyList());
+                        userId, null, Collections.emptyList());
                 auth.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
                 SecurityContextHolder.getContext().setAuthentication(auth);
             } catch (IllegalArgumentException | JWTVerificationException e) {

--- a/src/main/java/org/sopt/service/PostService.java
+++ b/src/main/java/org/sopt/service/PostService.java
@@ -7,6 +7,8 @@ import org.sopt.dto.request.UpdatePostRequest;
 import org.sopt.dto.response.CreatePostResponse;
 import org.sopt.dto.response.PostResponse;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import org.sopt.exception.BaseException;
 import org.sopt.exception.ErrorCode;
 import org.sopt.exception.PostNotFoundException;
@@ -45,8 +47,9 @@ public class PostService {
     @Transactional(readOnly = true)
     public Page<PostResponse> getAllPosts(int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
-        return postRepository.findAll(pageable)
-                .map(post -> PostResponse.from(post, likeRepository.countByPost(post)));
+        Page<Post> posts = postRepository.findAll(pageable);
+        Map<Long, Long> likeCountMap = getLikeCountMap(posts.getContent());
+        return posts.map(post -> PostResponse.from(post, likeCountMap.getOrDefault(post.getId(), 0L)));
     }
 
     // READ ONE
@@ -73,10 +76,20 @@ public class PostService {
     // SEARCH
     @Transactional(readOnly = true)
     public List<PostResponse> searchPosts(String title, String nickname) {
-        return postRepository.searchPosts(title, nickname)
-                .stream()
-                .map(post -> PostResponse.from(post, likeRepository.countByPost(post)))
+        List<Post> posts = postRepository.searchPosts(title, nickname);
+        Map<Long, Long> likeCountMap = getLikeCountMap(posts);
+        return posts.stream()
+                .map(post -> PostResponse.from(post, likeCountMap.getOrDefault(post.getId(), 0L)))
                 .toList();
+    }
+
+    private Map<Long, Long> getLikeCountMap(List<Post> posts) {
+        List<Long> postIds = posts.stream().map(Post::getId).toList();
+        return likeRepository.countByPostIds(postIds).stream()
+                .collect(Collectors.toMap(
+                        row -> (Long) row[0],
+                        row -> (Long) row[1]
+                ));
     }
 
     // DELETE

--- a/src/main/java/org/sopt/service/PostService.java
+++ b/src/main/java/org/sopt/service/PostService.java
@@ -6,6 +6,7 @@ import org.sopt.dto.request.CreatePostRequest;
 import org.sopt.dto.request.UpdatePostRequest;
 import org.sopt.dto.response.CreatePostResponse;
 import org.sopt.dto.response.PostResponse;
+import java.util.List;
 import org.sopt.exception.BaseException;
 import org.sopt.exception.ErrorCode;
 import org.sopt.exception.PostNotFoundException;
@@ -67,6 +68,15 @@ public class PostService {
         }
 
         post.update(request.title(), request.content());
+    }
+
+    // SEARCH
+    @Transactional(readOnly = true)
+    public List<PostResponse> searchPosts(String title, String nickname) {
+        return postRepository.searchPosts(title, nickname)
+                .stream()
+                .map(post -> PostResponse.from(post, likeRepository.countByPost(post)))
+                .toList();
     }
 
     // DELETE


### PR DESCRIPTION
# 🔥 *Pull Requests*

- Closes #23

## 👷 **과제 구현**

### 필수과제
- [x] 1차~6차 세미나에서 배운 내용 중 아직 글로 정리해보지 않은 주제를 골라서 아티클을 작성해주세요.
주제는 자유롭게 선택하되, 단순 요약이 아니라 내가 이해한 것을 내 언어로 설명하는 방식으로 써주세요.

<br>

### 선택과제
- [x] 아티클 주제와 관련된 기능을 에브리타임 클론 프로젝트에 직접 구현해주세요.
구현한 내용과 과정에서 배운 점을 PR 설명에 함께 작성해주세요.

<br>

### **구현한 내용에 대해서 설명해주세요**

#### 1. QueryDSL 세팅

build.gradle에 QueryDSL 관련 의존성을 추가하고, QueryDslConfig에서 JPAQueryFactory를 빈으로 등록했습니다.
이를 통해 Repository 구현체에서 JPAQueryFactory를 주입받아 QueryDSL 쿼리를 작성할 수 있도록 설정했습니다.

#### 2. QueryDSL 기반 게시글 동적 검색 구현

게시글 검색 기능을 QueryDSL 기반으로 구현했습니다.
먼저 PostRepositoryCustom 인터페이스에 searchPosts() 메서드를 선언하고,
PostRepositoryCustomImpl에서 해당 메서드의 실제 검색 로직을 QueryDSL로 구현했습니다.
또한, PostRepository가 JpaRepository와 PostRepositoryCustom을 함께 상속하도록 구성했습니다.
이렇게 구성하면 서비스 계층에서는 PostRepository 하나만 사용해도 기본 CRUD 기능과 커스텀한 검색 기능을 함께 사용할 수 있습니다.

<br>

### **구현하며 고민했던 내용을 적어주세요 (사소한 것도 좋아요)**

엄.. 사실 지금 게시글 목록을 조회할 때 각 게시글마다 `likeRepository.countByPost()`를 호출하고 있어,
N+1 문제가 발생하고 있습니다...

이를 해결하기 위해 몇 가지 방법을 고민해봤습니다.

- 게시글 목록을 조회할 때 좋아요 수까지 함께 조회하기  
  - QueryDSL로 게시글과 좋아요 수를 함께 가져오는 방식
- 게시글 엔티티에 `likeCount` 컬럼을 따로 두기  
  - 조회할 때는 빠르지만 좋아요 생성/취소 시 count 값 정합성을 신경 써야 함
- 게시글 id 목록으로 좋아요 수를 한 번에 조회한 뒤 매핑하기  
  - 게시글마다 count 쿼리를 날리지 않고, 한 번의 쿼리로 좋아요 수를 조회하는 방식

그런데 머리를 데굴 굴려봐도 어떤 방식이 최선인지 감이 오질 않아 일단 과제를 올려두고 추후에 개선해 반영하겠습니다... 😥

👉 이후 고민을 더 해보니,
게시글 id 목록으로 좋아요 수를 한 번에 조회한 뒤 매핑하는 방식이 현재 상황에 가장 적합하다고 판단했습니다!

QueryDSL로 게시글과 좋아요 수를 함께 조회하는 방식은 쿼리가 복잡해질 수 있고,
`likeCount` 컬럼을 따로 두는 방식은 좋아요 생성/취소 시 정합성을 계속 관리해야 한다는 부담이 있었습니다.
반면, 현재 선택한 방식은 스키마 변경 없이 게시글 조회 1번, 좋아요 수 일괄 조회 1번으로 N+1 문제를 줄일 수 있기 때문에,
가장 단순하고 안정적인 방법이라고 생각해 구현했습니다.

<br>

---

## 🚨 참고 사항
